### PR TITLE
Fix malformed path in Dockerfile

### DIFF
--- a/docker/tvm-v0.21/Dockerfile
+++ b/docker/tvm-v0.21/Dockerfile
@@ -27,7 +27,7 @@ RUN git clone https://github.com/emscripten-core/emsdk.git /opt/emsdk && \
     /opt/emsdk/emsdk activate latest && \
     echo "source /opt/emsdk/emsdk_env.sh" >> /etc/profile.d/emsdk.sh
 
-ENV PATH="/opt/emsdk:/opt/emsdk/node/${PATH}:/opt/emsdk/llvm/bin:${PATH}"
+ENV PATH="/opt/emsdk:/opt/emsdk/node/bin:/opt/emsdk/llvm/bin:${PATH}"
 
 # Build TVM v0.21
 # We will clone the v0.21 tag and perform an out-of-source build with CMake


### PR DESCRIPTION
Fix malformed PATH in `docker/tvm-v0.21/Dockerfile` to correctly locate Emscripten's Node.js binaries and tools.

The previous `ENV PATH` declaration incorrectly embedded `"${PATH}"` within the `/opt/emsdk/node/` segment, creating an invalid directory path and preventing Emscripten's Node.js and other tools from being found. This PR replaces the erroneous `"${PATH}"` with `node/bin`.

---
<a href="https://cursor.com/background-agent?bcId=bc-8f9fee70-e37b-4581-a580-ef8549071fa7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8f9fee70-e37b-4581-a580-ef8549071fa7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes `ENV PATH` to use `/opt/emsdk/node/bin` instead of malformed `/opt/emsdk/node/${PATH}`, ensuring Emscripten tools are discoverable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d84d0074b39f5e035002e52b266276f56e416e00. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->